### PR TITLE
Fix void pointer types to build with go 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: go
 
 go:
   - 1.2
+  - 1.3
+  - 1.4
 
 before_install:
   - export PATH=$HOME/gopath/bin:$PATH

--- a/eco/geom.go
+++ b/eco/geom.go
@@ -11,13 +11,13 @@ import (
 )
 
 type Geom struct {
-	geom   *[0]byte
-	preped *[0]byte
+	geom   *C.struct_GEOSGeom_t
+	preped *C.struct_GEOSPrepGeom_t
 }
 
 type Point struct {
-	coordseqptr *[0]byte
-	pointptr    *[0]byte
+	coordseqptr *C.struct_GEOSCoordSeq_t
+	pointptr    *C.struct_GEOSGeom_t
 }
 
 type Region struct {


### PR DESCRIPTION
fixes #22 on github

tested to also build inside the VM with go 1.2