### PR TITLE
Log fatal instead of panic on db connection error

### DIFF
--- a/ecorest/cache/main.go
+++ b/ecorest/cache/main.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"errors"
 	"fmt"
+	"log"
 	"github.com/azavea/ecobenefits/eco"
 	"github.com/azavea/ecobenefits/ecorest/config"
 )
@@ -45,7 +46,10 @@ func Init(cfg config.Config) (*Cache, func()) {
 		speciesdata, err := eco.LoadSpeciesMap(cfg.Data.Path + "/species.json")
 		config.PanicOnError(err)
 		overrides, err := db.GetOverrideMap()
-		config.PanicOnError(err)
+
+		if err != nil {
+			log.Fatal(err)
+		}
 
 		regiongeometry, err := db.GetRegionGeoms()
 		config.PanicOnError(err)


### PR DESCRIPTION
prints:
```
2015/03/07 20:17:39 dial tcp 127.0.0.1:5432: connection refused
```

instead of a large, unneccessary stacktrace. It's clear for anyone who
works on this what the problem is from the `5432`.